### PR TITLE
Github issue #81 - Username password auth

### DIFF
--- a/NVR Viewer/Model/Auth/AuthFrigateLogin.swift
+++ b/NVR Viewer/Model/Auth/AuthFrigateLogin.swift
@@ -1,0 +1,353 @@
+/*
+*  AuthFrigateLogin.swift
+*  NVR Viewer
+*
+*  Handles Frigate authentication using username and password, requests a login
+*  token, stores it securely, and retries once if the token has expired.
+*
+*  Created by CJ on 01/05/26.
+*
+*/
+import Foundation
+
+private enum FrigateLoginError: LocalizedError {
+    case missingHost
+    case missingUsername
+    case missingPassword
+    case invalidURL(String)
+    case invalidResponse
+    case unauthorized
+    case tokenMissing
+    case apiError(Int, String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingHost:
+            return "Missing Frigate host"
+        case .missingUsername:
+            return "Missing Frigate username"
+        case .missingPassword:
+            return "Missing Frigate password"
+        case .invalidURL(let value):
+            return "Invalid URL: \(value)"
+        case .invalidResponse:
+            return "Invalid response from Frigate login"
+        case .unauthorized:
+            return "Frigate login failed: unauthorized"
+        case .tokenMissing:
+            return "Frigate login succeeded but no token was returned"
+        case .apiError(let code, let body):
+            return "Frigate login failed with status \(code). \(body)"
+        }
+    }
+}
+
+private struct FrigateLoginRequest: Encodable {
+    let user: String
+    let password: String
+}
+
+final class AuthFrigateLogin {
+    static let shared = AuthFrigateLogin()
+
+    private let credentialStore = FrigateCredentialStore.shared
+
+    private init() {}
+
+    private func normalizedBaseURL(_ host: String) -> String {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasSuffix("/") {
+            return String(trimmed.dropLast())
+        }
+        return trimmed
+    }
+
+    private func makeURL(base: String, endpoint: String) throws -> URL {
+        let normalizedBase = normalizedBaseURL(base)
+        guard !normalizedBase.isEmpty else {
+            throw FrigateLoginError.missingHost
+        }
+
+        let normalizedEndpoint: String
+        if endpoint.isEmpty {
+            normalizedEndpoint = ""
+        } else if endpoint.hasPrefix("/") {
+            normalizedEndpoint = endpoint
+        } else {
+            normalizedEndpoint = "/" + endpoint
+        }
+
+        let urlString = normalizedBase + normalizedEndpoint
+        guard let url = URL(string: urlString) else {
+            throw FrigateLoginError.invalidURL(urlString)
+        }
+        return url
+    }
+
+    func saveCredentials(username: String, password: String) {
+        let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedUsername.isEmpty else {
+            Log.error(
+                page: "AuthFrigateLogin",
+                fn: "saveCredentials",
+                FrigateLoginError.missingUsername.localizedDescription
+            )
+            return
+        }
+
+        guard !password.isEmpty else {
+            Log.error(
+                page: "AuthFrigateLogin",
+                fn: "saveCredentials",
+                FrigateLoginError.missingPassword.localizedDescription
+            )
+            return
+        }
+
+        do {
+            try credentialStore.saveCredentials(
+                username: trimmedUsername,
+                password: password
+            )
+        } catch {
+            Log.error(
+                page: "AuthFrigateLogin",
+                fn: "saveCredentials",
+                error.localizedDescription
+            )
+        }
+    }
+
+    func clearStoredCredentials() {
+        do {
+            try credentialStore.clearCredentials()
+        } catch {
+            Log.error(
+                page: "AuthFrigateLogin",
+                fn: "clearStoredCredentials",
+                error.localizedDescription
+            )
+        }
+    }
+
+    func clearStoredToken(host: String) {
+        do {
+            try credentialStore.clearToken(forHost: host)
+        } catch {
+            Log.error(
+                page: "AuthFrigateLogin",
+                fn: "clearStoredToken",
+                error.localizedDescription
+            )
+        }
+    }
+
+    func storedToken(host: String) -> String? {
+        do {
+            return try credentialStore.token(forHost: host)
+        } catch {
+            Log.error(
+                page: "AuthFrigateLogin",
+                fn: "storedToken",
+                error.localizedDescription
+            )
+            return nil
+        }
+    }
+
+    func login(host: String) async throws -> String {
+        guard let credentials = try credentialStore.credentials() else {
+            let hasUsername = (try credentialStore.credentials()?.username) != nil
+            if hasUsername {
+                throw FrigateLoginError.missingPassword
+            } else {
+                throw FrigateLoginError.missingUsername
+            }
+        }
+
+        let url = try makeURL(base: host, endpoint: "/api/login")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = try JSONEncoder().encode(
+            FrigateLoginRequest(
+                user: credentials.username,
+                password: credentials.password
+            )
+        )
+
+        let configuration = URLSessionConfiguration.default
+        configuration.httpCookieStorage = HTTPCookieStorage.shared
+        configuration.httpShouldSetCookies = true
+
+        let delegate = FrigateURLSessionDelegate()
+        let session = URLSession(
+            configuration: configuration,
+            delegate: delegate,
+            delegateQueue: nil
+        )
+
+        defer {
+            session.finishTasksAndInvalidate()
+        }
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw FrigateLoginError.invalidResponse
+        }
+
+        if http.statusCode == 401 {
+            throw FrigateLoginError.unauthorized
+        }
+
+        guard (200...299).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw FrigateLoginError.apiError(http.statusCode, body)
+        }
+
+        guard let token = extractToken(from: http, data: data, url: url) else {
+            throw FrigateLoginError.tokenMissing
+        }
+
+        try credentialStore.saveToken(token, forHost: host)
+
+        Log.debug(
+            page: "AuthFrigateLogin",
+            fn: "login",
+            "Stored Frigate-issued token in Keychain"
+        )
+
+        return token
+    }
+
+    func token(host: String, forceRefresh: Bool = false) async throws -> String {
+        if !forceRefresh, let existing = storedToken(host: host) {
+            return existing
+        }
+
+        clearStoredToken(host: host)
+        return try await login(host: host)
+    }
+
+    func connect(
+        host: String,
+        endpoint: String,
+        forceRefresh: Bool = false,
+        completion: @escaping (Data?, Error?) -> Void
+    ) async {
+        do {
+            let token = try await token(host: host, forceRefresh: forceRefresh)
+
+            await connectToFrigateAPIWithJWT(
+                host: host,
+                jwtToken: token,
+                endpoint: endpoint
+            ) { data, error in
+                if let nsError = error as NSError?,
+                   nsError.domain == "APIError",
+                   nsError.code == 401,
+                   !forceRefresh {
+                    Log.debug(
+                        page: "AuthFrigateLogin",
+                        fn: "connect",
+                        "401 received, clearing cached token and retrying once"
+                    )
+
+                    self.clearStoredToken(host: host)
+
+                    Task {
+                        await self.connect(
+                            host: host,
+                            endpoint: endpoint,
+                            forceRefresh: true,
+                            completion: completion
+                        )
+                    }
+                    return
+                }
+
+                completion(data, error)
+            }
+        } catch {
+            Log.error(
+                page: "AuthFrigateLogin",
+                fn: "connect",
+                error.localizedDescription
+            )
+            completion(nil, error)
+        }
+    }
+
+    private func extractToken(
+        from response: HTTPURLResponse,
+        data: Data,
+        url: URL
+    ) -> String? {
+        let headerFields: [String: String] = response.allHeaderFields.reduce(into: [:]) { result, item in
+            guard let key = item.key as? String else { return }
+            guard let value = item.value as? String else { return }
+            result[key] = value
+        }
+
+        let cookiesFromHeaders = HTTPCookie.cookies(
+            withResponseHeaderFields: headerFields,
+            for: url
+        )
+        if let token = tokenFromCookies(cookiesFromHeaders) {
+            return token
+        }
+
+        if let storedCookies = HTTPCookieStorage.shared.cookies(for: url),
+           let token = tokenFromCookies(storedCookies) {
+            return token
+        }
+
+        if !data.isEmpty,
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            for key in ["access_token", "token", "jwt", "frigate_token", "frigate-token"] {
+                if let token = object[key] as? String {
+                    let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        return trimmed
+                    }
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private func tokenFromCookies(_ cookies: [HTTPCookie]) -> String? {
+        let preferredNames: Set<String> = [
+            "frigate_token",
+            "frigate-token"
+        ]
+
+        if let cookie = cookies.first(where: {
+            preferredNames.contains($0.name.lowercased()) &&
+            !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) {
+            return cookie.value
+        }
+
+        if let cookie = cookies.first(where: {
+            $0.name.lowercased().contains("frigate") &&
+            !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) {
+            return cookie.value
+        }
+
+        if let cookie = cookies.first(where: {
+            $0.name.lowercased().contains("token") &&
+            !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) {
+            return cookie.value
+        }
+
+        return nil
+    }
+}

--- a/NVR Viewer/Model/Auth/FrigateCredentialStore.swift
+++ b/NVR Viewer/Model/Auth/FrigateCredentialStore.swift
@@ -1,0 +1,93 @@
+
+/*
+*  FrigateCredentialStore.swift
+*  NVR Viewer
+*
+*  Uses KeychainStore to manage Frigate credentials
+*  in a single place for the app's authentication flow.
+*  Created by CJ on 01/05/26.
+*
+*/
+import Foundation
+
+struct FrigateCredentials {
+    let username: String
+    let password: String
+}
+
+final class FrigateCredentialStore {
+    static let shared = FrigateCredentialStore()
+
+    private let keychain: KeychainStore
+
+    private let usernameAccount = "frigate.username"
+    private let passwordAccount = "frigate.password"
+    private let tokenAccountPrefix = "frigate.token."
+
+    private init(
+        keychain: KeychainStore = KeychainStore(
+            service: (Bundle.main.bundleIdentifier ?? "NVRViewer") + ".frigate"
+        )
+    ) {
+        self.keychain = keychain
+    }
+
+    func saveCredentials(username: String, password: String) throws {
+        let trimmedUsername = username.trimmingCharacters(in: .whitespacesAndNewlines)
+        try keychain.save(trimmedUsername, account: usernameAccount)
+        try keychain.save(password, account: passwordAccount)
+    }
+
+    func credentials() throws -> FrigateCredentials? {
+        guard
+            let username = try keychain.read(account: usernameAccount)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !username.isEmpty,
+            let password = try keychain.read(account: passwordAccount),
+            !password.isEmpty
+        else {
+            return nil
+        }
+
+        return FrigateCredentials(username: username, password: password)
+    }
+
+    func clearCredentials() throws {
+        try keychain.delete(account: usernameAccount)
+        try keychain.delete(account: passwordAccount)
+    }
+
+    func saveToken(_ token: String, forHost host: String) throws {
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedToken.isEmpty else { return }
+        try keychain.save(trimmedToken, account: tokenAccount(for: host))
+    }
+
+    func token(forHost host: String) throws -> String? {
+        guard
+            let token = try keychain.read(account: tokenAccount(for: host))?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !token.isEmpty
+        else {
+            return nil
+        }
+
+        return token
+    }
+
+    func clearToken(forHost host: String) throws {
+        try keychain.delete(account: tokenAccount(for: host))
+    }
+
+    private func tokenAccount(for host: String) -> String {
+        tokenAccountPrefix + normalizedHostKey(host)
+    }
+
+    private func normalizedHostKey(_ host: String) -> String {
+        var value = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
+        return value.lowercased()
+    }
+}

--- a/NVR Viewer/Model/Auth/KeychainStore.swift
+++ b/NVR Viewer/Model/Auth/KeychainStore.swift
@@ -1,0 +1,101 @@
+/*
+*  KeychainStore.swift
+*  NVR Viewer
+*
+*  Provides a small wrapper around Keychain Services for securely saving,
+*  reading, and deleting sensitive string values such as credentials and tokens.
+*
+*  Created by CJ on 01/05/26.
+*
+*/
+import Foundation
+import Security
+
+enum KeychainStoreError: LocalizedError {
+    case unexpectedStatus(OSStatus)
+    case invalidData
+
+    var errorDescription: String? {
+        switch self {
+        case .unexpectedStatus(let status):
+            return "Keychain error: \(status)"
+        case .invalidData:
+            return "Invalid data returned from Keychain"
+        }
+    }
+}
+
+final class KeychainStore {
+    private let service: String
+    private let accessible: CFString
+
+    init(
+        service: String,
+        accessible: CFString = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+    ) {
+        self.service = service
+        self.accessible = accessible
+    }
+
+    func save(_ value: String, account: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        SecItemDelete(query as CFDictionary)
+
+        var attributes = query
+        attributes[kSecValueData as String] = Data(value.utf8)
+        attributes[kSecAttrAccessible as String] = accessible
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw KeychainStoreError.unexpectedStatus(status)
+        }
+    }
+
+    func read(account: String) throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data else {
+                throw KeychainStoreError.invalidData
+            }
+            guard let value = String(data: data, encoding: .utf8) else {
+                throw KeychainStoreError.invalidData
+            }
+            return value
+
+        case errSecItemNotFound:
+            return nil
+
+        default:
+            throw KeychainStoreError.unexpectedStatus(status)
+        }
+    }
+
+    func delete(account: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw KeychainStoreError.unexpectedStatus(status)
+        }
+    }
+}

--- a/NVR Viewer/View/Settings/Auth/ViewAuthFrigate.swift
+++ b/NVR Viewer/View/Settings/Auth/ViewAuthFrigate.swift
@@ -20,6 +20,9 @@ struct ViewAuthFrigate: View {
     @AppStorage("frigatePortAddress") private var nvrPortAddress: String = "8971"
     @AppStorage("frigateIsHttps") private var nvrIsHttps: Bool = true
     @AppStorage("frigateBearerSecret") private var frigateBearerSecret: String = ""
+    @AppStorage("frigateUser") private var frigateUser: String = "admin"
+    @AppStorage("frigatePassword") private var frigatePassword: String = ""
+    @State private var showPassword = false
 
     @Environment(\.colorScheme) var colorScheme
 
@@ -70,33 +73,48 @@ struct ViewAuthFrigate: View {
             // MARK: HTTPS toggle
             Toggle("Https", isOn: $nvrIsHttps)
                 .tint(Color(red: 0.153, green: 0.69, blue: 1))
+            
+            // CJ: Removed bearer to allow for username and password.
 
             Divider()
 
-            // MARK: Secret (JWT)
             HStack(spacing: 8) {
-                Text("Secret")
+                Text("Username")
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                ZStack {
-                    if !showBearer {
-                        SecureField("", text: $frigateBearerSecret)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                TextField("Username", text: $frigateUser)
+                    .autocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Divider()
+
+            HStack(spacing: 8) {
+                Text("Password")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Group {
+                    if showPassword {
+                        TextField("Password", text: $frigatePassword)
+                            .autocapitalization(.never)
+                            .autocorrectionDisabled()
                     } else {
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            TextField("secret goes here", text: $frigateBearerSecret)
-                                .autocapitalization(.none)
-                                .autocorrectionDisabled()
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
+                        SecureField("Password", text: $frigatePassword)
+                            .autocapitalization(.never)
+                            .autocorrectionDisabled()
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                Button("", systemImage: showBearer ? "eye.slash" : "eye") {
-                    showBearer.toggle()
+                Button {
+                    showPassword.toggle()
+                } label: {
+                    Image(systemName: showPassword ? "eye.slash" : "eye")
                 }
                 .buttonStyle(.borderless)
                 .foregroundStyle(Color(red: 0.153, green: 0.69, blue: 1))
+                .accessibilityLabel(showPassword ? "Hide password" : "Show password")
             }
 
             Divider()
@@ -114,13 +132,17 @@ struct ViewAuthFrigate: View {
             )
 
             // MARK: Save button
+            // CJ: Updated to clear cached token and to save credentials.
             HStack {
                 Spacer()
 
                 Button("Save Connection") {
-
                     let host = normalizedHost(nvrIPAddress)
+                    let username = frigateUser.trimmingCharacters(in: .whitespacesAndNewlines)
+                    let password = frigatePassword
+
                     nvrIPAddress = host
+                    frigateUser = username
 
                     // IMPORTANT: set profile first so subsequent setIP/setPort save to the Frigate keys
                     nvrManager.setAuthType(authType: .frigate)
@@ -129,17 +151,28 @@ struct ViewAuthFrigate: View {
                     nvrManager.setIP(ip: host)
                     nvrManager.setPort(ports: nvrPortAddress)
 
+                    // Clear any old cached token so this save actually tests the new credentials
+                    AuthFrigateLogin.shared.clearStoredToken()
+                    AuthFrigateLogin.shared.saveCredentials(
+                        username: username,
+                        password: password
+                    )
+
                     nvrManager.connectionState = .disconnected
+                    // If you have a .connecting state, use that instead.
 
                     Task {
-                        let urlString = buildURLString(isHttps: nvrIsHttps, host: host, port: nvrPortAddress)
+                        let urlString = buildURLString(
+                            isHttps: nvrIsHttps,
+                            host: host,
+                            port: nvrPortAddress
+                        )
 
                         do {
                             try await api.checkConnectionStatus(
                                 urlString: urlString,
                                 authType: .frigate
                             ) { _, error in
-
                                 if let error = error {
                                     Log.error(
                                         page: "ViewAuthFrigate",
@@ -214,9 +247,17 @@ struct ViewAuthFrigate: View {
         }
     }
 
+    // CJ: Updated to exclude ':' from URL when there is no port specified
     private func buildURLString(isHttps: Bool, host: String, port: String) -> String {
         let scheme = isHttps ? "https://" : "http://"
-        return "\(scheme)\(host):\(port)"
+        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPort = port.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmedPort.isEmpty {
+            return "\(scheme)\(trimmedHost)"
+        } else {
+            return "\(scheme)\(trimmedHost):\(trimmedPort)"
+        }
     }
 
     private func normalizedHost(_ raw: String) -> String {

--- a/NVR Viewer/ViewModel/APIRequestor.swift
+++ b/NVR Viewer/ViewModel/APIRequestor.swift
@@ -1,22 +1,31 @@
-//
-//  APIRequestor.swift
-//  NVR Viewer
-//
-//  Created by Matthew Ehrhart on 3/13/24.
-//
+/*
+*  APIRequestor.swift
+*  NVR Viewer
+*
+*  Performs authenticated and unauthenticated requests to the NVR and Frigate
+*  APIs, including config, events, images, and connection checks.
+*
+*  Created by Matthew Ehrhart on 3/13/24.
+*  Updated by CJ to use AuthFrigateLogin for Frigate login-based auth.
+*
+*/
 
 import Foundation
 import JWTKit
 
 final class APIRequester: NSObject {
-    
+
     // MARK: - Helpers
 
     /// Normalizes `base` + `endpoint` into a single URL:
+    /// - trims whitespace
     /// - trims a trailing "/" from base
     /// - ensures endpoint either starts with "/" or is empty
     private func makeURL(base: String, endpoint: String) -> URL? {
-        let trimmedBase = base.hasSuffix("/") ? String(base.dropLast()) : base
+        let trimmed = base.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let trimmedBase = trimmed.hasSuffix("/") ? String(trimmed.dropLast()) : trimmed
 
         let normalizedEndpoint: String
         if endpoint.isEmpty {
@@ -29,9 +38,168 @@ final class APIRequester: NSObject {
 
         return URL(string: trimmedBase + normalizedEndpoint)
     }
-    
+
+    /// Splits a fully-qualified URL into:
+    /// - host/base   e.g. "https://example.local:8971"
+    /// - endpoint    e.g. "/api/events/123/snapshot.jpg?download=1"
+    ///
+    /// This is useful for authenticated image requests where callers pass a full URL,
+    /// but AuthFrigateLogin expects base host + endpoint separately.
+    private func splitAbsoluteURL(_ absoluteString: String) -> (host: String, endpoint: String)? {
+        let trimmed = absoluteString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            let components = URLComponents(string: trimmed),
+            let scheme = components.scheme,
+            let host = components.host
+        else {
+            return nil
+        }
+
+        var base = "\(scheme)://\(host)"
+        if let port = components.port {
+            base += ":\(port)"
+        }
+
+        let path = components.percentEncodedPath
+        let query = components.percentEncodedQuery.map { "?\($0)" } ?? ""
+        let endpoint = path + query
+
+        return (host: base, endpoint: endpoint)
+    }
+
+    private func makeError(
+        domain: String = "APIRequester",
+        code: Int,
+        message: String
+    ) -> NSError {
+        NSError(
+            domain: domain,
+            code: code,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+
+    private func finish(
+        completion: @escaping (Data?, Error?) -> Void,
+        data: Data?,
+        error: Error?
+    ) {
+        if Thread.isMainThread {
+            completion(data, error)
+        } else {
+            DispatchQueue.main.async {
+                completion(data, error)
+            }
+        }
+    }
+
+    private func performRequest(
+        url: URL,
+        method: String,
+        completion: @escaping (Data?, Error?) -> Void
+    ) {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+
+        let session = URLSession(
+            configuration: .default,
+            delegate: self,
+            delegateQueue: .main
+        )
+
+        let task = session.dataTask(with: request) { data, _, error in
+            defer { session.finishTasksAndInvalidate() }
+            self.finish(completion: completion, data: data, error: error)
+        }
+        task.resume()
+    }
+
+    private func performImageRequest(
+        url: URL,
+        completion: @escaping (Data?, Error?) -> Void
+    ) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        let session = URLSession(
+            configuration: .default,
+            delegate: self,
+            delegateQueue: .main
+        )
+
+        let task = session.dataTask(with: request) { data, _, error in
+            defer { session.finishTasksAndInvalidate() }
+
+            guard let data = data else {
+                self.finish(completion: completion, data: nil, error: error)
+                return
+            }
+
+            if data.count < 50 {
+                do {
+                    let decoded = try JSONDecoder().decode(FrigateResponse.self, from: data)
+                    if decoded.success == false {
+                        let errorTemp = NSError(
+                            domain: "com.john.matthew",
+                            code: 101,
+                            userInfo: [NSLocalizedDescriptionKey: decoded.message ?? "Frigate image request failed"]
+                        )
+                        self.finish(completion: completion, data: nil, error: errorTemp)
+                        return
+                    }
+                } catch {
+                    Log.error(
+                        page: "APIRequestor",
+                        fn: "fetchImage",
+                        "\(error)"
+                    )
+                }
+            }
+
+            self.finish(completion: completion, data: data, error: error)
+        }
+        task.resume()
+    }
+
+    private func validateVersionPayload(
+        data: Data?,
+        error: Error?,
+        completion: @escaping (Data?, Error?) -> Void
+    ) {
+        if let error = error {
+            finish(completion: completion, data: nil, error: error)
+            return
+        }
+
+        guard let data = data, !data.isEmpty else {
+            finish(
+                completion: completion,
+                data: nil,
+                error: makeError(domain: "connection.info", code: 500, message: "Empty response")
+            )
+            return
+        }
+
+        if let firstByte = data.first {
+            let firstByteData = Data([firstByte])
+            if let firstCharacterString = String(data: firstByteData, encoding: .utf8) {
+                let character = Character(firstCharacterString)
+                if !character.isWholeNumber {
+                    finish(
+                        completion: completion,
+                        data: nil,
+                        error: makeError(domain: "connection.info", code: 500, message: "Unexpected response format")
+                    )
+                    return
+                }
+            }
+        }
+
+        finish(completion: completion, data: data, error: nil)
+    }
+
     // MARK: - Frigate Plus
-    
+
     /// Posts an image to FrigatePlus. `eventId` is currently unused but kept to avoid breaking callers.
     func postImageToFrigatePlus(
         urlString: String,
@@ -43,145 +211,120 @@ final class APIRequester: NSObject {
         switch authType {
         case .none:
             guard let url = makeURL(base: urlString, endpoint: endpoint) else {
-                let error = NSError(
+                let error = makeError(
                     domain: "InvalidURL",
                     code: 0,
-                    userInfo: [NSLocalizedDescriptionKey: "Invalid URL in postImageToFrigatePlus: base=\(urlString), endpoint=\(endpoint)"]
+                    message: "Invalid URL in postImageToFrigatePlus: base=\(urlString), endpoint=\(endpoint)"
                 )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "postImageToFrigatePlus", error.localizedDescription
+                    fn: "postImageToFrigatePlus",
+                    error.localizedDescription
                 )
-                completion(nil, error)
+                finish(completion: completion, data: nil, error: error)
                 return
             }
 
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
+            performRequest(url: url, method: "POST", completion: completion)
 
-            let session = URLSession(
-                configuration: .default,
-                delegate: self,
-                delegateQueue: .main
-            )
-
-            let task = session.dataTask(with: request) { data, _, error in
-                completion(data, error)
-            }
-            task.resume()
-
-//            let fullURLString = urlString + endpoint
-//            guard let url = URL(string: fullURLString) else {
-//                Log.error(
-//                    page: "APIRequestor",
-//                    fn: "postImageToFrigatePlus", "Invalid URL: \(fullURLString)"
-//                )
-//                return
-//            }
-//            
-//            var request = URLRequest(url: url)
-//            request.httpMethod = "POST"
-//            
-//            let session = URLSession(
-//                configuration: .default,
-//                delegate: self,
-//                delegateQueue: .main
-//            )
-//            
-//            let task = session.dataTask(with: request) { data, _, error in
-//                completion(data, error)
-//            }
-//            task.resume()
-            
         case .frigate:
-            guard let jwt = try? await generateJWTFrigate() else {
-                Log.error(
-                    page: "APIRequestor",
-                    fn: "postImageToFrigatePlus", "Failed to generate Frigate JWT"
-                )
-                return
-            }
-            await connectToFrigateAPIWithJWT(
+            await AuthFrigateLogin.shared.connect(
                 host: urlString,
-                jwtToken: jwt,
                 endpoint: endpoint
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         case .bearer:
             guard let jwt = try? await generateJWTBearer() else {
+                let error = makeError(
+                    code: 503,
+                    message: "Failed to generate bearer JWT"
+                )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "postImageToFrigatePlus","Failed to generate bearer JWT"
+                    fn: "postImageToFrigatePlus",
+                    error.localizedDescription
                 )
+                finish(completion: completion, data: nil, error: error)
                 return
             }
+
             await connectWithJWT(
                 host: urlString,
                 jwtToken: jwt,
                 endpoint: endpoint
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         case .cloudflare:
             await AuthCloudFlare.shared().connectWithCloudflareAccess(
                 host: urlString,
                 endpoint: endpoint
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         default:
+            let error = makeError(
+                code: 400,
+                message: "unsupported authType \(authType)"
+            )
             Log.error(
                 page: "APIRequestor",
-                fn: "postImageToFrigatePlus", "unsupported authType \(authType)"
+                fn: "postImageToFrigatePlus",
+                error.localizedDescription
             )
+            finish(completion: completion, data: nil, error: error)
         }
     }
-    
+
     // MARK: - Events (background fetch)
-    
+
     func fetchEventsInBackground(
         urlString: String,
         backgroundFetchEventsEpochtime: String,
         epsType: String,
         authType: AuthType
     ) async {
-        
+
         let endpoint = "/api/events?limit=10000&after=\(backgroundFetchEventsEpochtime)"
-        
-        // update background fetch timestamp
-        let after = Int(Date().timeIntervalSince1970)
-        UserDefaults.standard.set(String(after), forKey: "background_fetch_events_epochtime")
-        
+        let nextAfter = Int(Date().timeIntervalSince1970)
+
         await fetchNVREvents(
             urlString: urlString,
             endpoint: endpoint,
             authType: authType
         ) { data, error in
-            
-            // Transport / API error
+
             if let error = error {
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchEventsInBackground", "Network/API error: \(error.localizedDescription)"
+                    fn: "fetchEventsInBackground",
+                    "Network/API error: \(error.localizedDescription)"
                 )
                 return
             }
-            
+
             guard let data = data else {
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchEventsInBackground", "No data returned from fetchNVREvents"
+                    fn: "fetchEventsInBackground",
+                    "No data returned from fetchNVREvents"
                 )
                 return
             }
-            
+
             do {
                 let arrayEvents = try JSONDecoder().decode([NVRConfigurationHTTP].self, from: data)
-                
+
+                // Only advance the cursor after a successful fetch/decode.
+                UserDefaults.standard.set(
+                    String(nextAfter),
+                    forKey: "background_fetch_events_epochtime"
+                )
+
                 if arrayEvents.isEmpty {
                     Log.debug(
                         page: "APIRequestor",
@@ -195,17 +338,17 @@ final class APIRequester: NSObject {
                         "Decoded \(arrayEvents.count) events from \(endpoint)"
                     )
                 }
-                
+
                 for event in arrayEvents {
                     let url = urlString
                     let id = event.id
                     let frameTime = event.start_time
-                    
+
                     var enteredZones = ""
                     for zone in event.zones ?? [] {
                         enteredZones += zone + "|"
                     }
-                    
+
                     var eps = EndpointOptions()
                     eps.snapshot       = url + "/api/events/\(id)/snapshot.jpg"
                     eps.cameraName     = event.camera
@@ -224,12 +367,12 @@ final class APIRequester: NSObject {
                     eps.currentZones   = ""
                     eps.enteredZones   = enteredZones
                     eps.sublabel       = event.sub_label
-                    
+
                     // normalize optionals to non-nil strings
                     if eps.sublabel == nil      { eps.sublabel      = "" }
                     if eps.currentZones == nil  { eps.currentZones  = "" }
                     if eps.enteredZones == nil  { eps.enteredZones  = "" }
-                    
+
                     _ = EventStorage.shared.insertOrUpdate(
                         id: eps.id!,
                         frameTime: eps.frameTime!,
@@ -253,12 +396,13 @@ final class APIRequester: NSObject {
             } catch {
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchEventsInBackground", "JSON decode error: \(error)"
+                    fn: "fetchEventsInBackground",
+                    "JSON decode error: \(error)"
                 )
             }
         }
     }
-    
+
     /// Low-level events fetcher used by background logic and potentially others.
     func fetchNVREvents(
         urlString: String,
@@ -269,108 +413,77 @@ final class APIRequester: NSObject {
         switch authType {
         case .none:
             guard let url = makeURL(base: urlString, endpoint: endpoint) else {
-                let error = NSError(
+                let error = makeError(
                     domain: "InvalidURL",
                     code: 0,
-                    userInfo: [NSLocalizedDescriptionKey: "Invalid URL in fetchNVREvents: base=\(urlString), endpoint=\(endpoint)"]
+                    message: "Invalid URL in fetchNVREvents: base=\(urlString), endpoint=\(endpoint)"
                 )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchNVREvents", error.localizedDescription
+                    fn: "fetchNVREvents",
+                    error.localizedDescription
                 )
-                completion(nil, error)
+                finish(completion: completion, data: nil, error: error)
                 return
             }
 
-            var request = URLRequest(url: url)
-            request.httpMethod = "GET"
+            performRequest(url: url, method: "GET", completion: completion)
 
-            let session = URLSession(
-                configuration: .default,
-                delegate: self,
-                delegateQueue: .main
-            )
-
-            let task = session.dataTask(with: request) { data, _, error in
-                completion(data, error)
-            }
-            task.resume()
-
-//            let urlStringEvents = urlString + endpoint
-//            guard let url = URL(string: urlStringEvents) else {
-//                Log.error(
-//                    page: "APIRequestor",
-//                    fn: "fetchNVREvents", "Invalid URL: \(urlStringEvents)"
-//                )
-//                return
-//            }
-//            
-//            var request = URLRequest(url: url)
-//            request.httpMethod = "GET"
-//            
-//            let session = URLSession(
-//                configuration: .default,
-//                delegate: self,
-//                delegateQueue: .main
-//            )
-//            
-//            let task = session.dataTask(with: request) { data, _, error in
-//                completion(data, error)
-//            }
-//            task.resume()
-            
         case .frigate:
-            guard let jwt = try? await generateJWTFrigate() else {
-                Log.error(
-                    page: "APIRequestor",
-                    fn: "fetchNVREvents", "Failed to generate Frigate JWT"
-                )
-                return
-            }
-            await connectToFrigateAPIWithJWT(
+            await AuthFrigateLogin.shared.connect(
                 host: urlString,
-                jwtToken: jwt,
                 endpoint: endpoint
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         case .bearer:
             guard let jwt = try? await generateJWTBearer() else {
+                let error = makeError(
+                    code: 503,
+                    message: "Failed to generate bearer JWT"
+                )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchNVREvents", "Failed to generate bearer JWT"
+                    fn: "fetchNVREvents",
+                    error.localizedDescription
                 )
+                finish(completion: completion, data: nil, error: error)
                 return
             }
-            // IMPORTANT: use `endpoint` (e.g. /api/events...) rather than hardcoding /api/config
+
             await connectWithJWT(
                 host: urlString,
                 jwtToken: jwt,
                 endpoint: endpoint
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         case .cloudflare:
-            // IMPORTANT: use `endpoint` here as well
             await AuthCloudFlare.shared().connectWithCloudflareAccess(
                 host: urlString,
                 endpoint: endpoint
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         default:
+            let error = makeError(
+                code: 400,
+                message: "unsupported authType \(authType)"
+            )
             Log.error(
                 page: "APIRequestor",
-                fn: "fetchNVREvents", "unsupported authType \(authType)"
+                fn: "fetchNVREvents",
+                error.localizedDescription
             )
+            finish(completion: completion, data: nil, error: error)
         }
     }
-    
+
     // MARK: - Images
-    
+
     func fetchImage(
         urlString: String,
         authType: AuthType,
@@ -379,155 +492,122 @@ final class APIRequester: NSObject {
         switch authType {
         case .none:
             guard let url = URL(string: urlString) else {
-                let error = NSError(
+                let error = makeError(
                     domain: "InvalidURL",
                     code: 0,
-                    userInfo: [NSLocalizedDescriptionKey: "Invalid image URL: \(urlString)"]
+                    message: "Invalid image URL: \(urlString)"
                 )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchImage", error.localizedDescription
+                    fn: "fetchImage",
+                    error.localizedDescription
                 )
-                completion(nil, error)
+                finish(completion: completion, data: nil, error: error)
                 return
             }
 
-            var request = URLRequest(url: url)
-            request.httpMethod = "GET"
+            performImageRequest(url: url, completion: completion)
 
-            let session = URLSession(
-                configuration: .default,
-                delegate: self,
-                delegateQueue: .main
-            )
-
-            let task = session.dataTask(with: request) { data, _, error in
-                guard let data = data else {
-                    completion(nil, error)
-                    return
-                }
-
-                if data.count < 50 {
-                    do {
-                        let decoded = try JSONDecoder().decode(FrigateResponse.self, from: data)
-                        if decoded.success == false {
-                            let errorTemp = NSError(
-                                domain: "com.john.matthew",
-                                code: 101,
-                                userInfo: nil
-                            )
-                            completion(nil, errorTemp)
-                            return
-                        }
-                    } catch {
-                        Log.error(
-                            page: "APIRequestor",
-                            fn: "fetchImage", "\(error)"
-                        )
-                    }
-                }
-
-                completion(data, error)
-            }
-            task.resume()
-
-//            guard let url = URL(string: urlString) else {
-//                Log.error(
-//                    page: "APIRequestor",
-//                    fn: "fetchImage", "Invalid URL: \(urlString)"
-//                )
-//                return
-//            }
-//            
-//            var request = URLRequest(url: url)
-//            request.httpMethod = "GET"
-//            
-//            let session = URLSession(
-//                configuration: .default,
-//                delegate: self,
-//                delegateQueue: .main
-//            )
-//            
-//            let task = session.dataTask(with: request) { data, _, error in
-//                guard let data = data else {
-//                    completion(nil, error)
-//                    return
-//                }
-//                
-//                if data.count < 50 {
-//                    do {
-//                        let decoded = try JSONDecoder().decode(FrigateResponse.self, from: data)
-//                        if decoded.success == false {
-//                            let errorTemp = NSError(
-//                                domain: "com.john.matthew",
-//                                code: 101,
-//                                userInfo: nil
-//                            )
-//                            completion(nil, errorTemp)
-//                            return
-//                        }
-//                    } catch {
-//                        Log.error(
-//                            page: "APIRequestor",
-//                            fn: "fetchImage", "\(error)"
-//                        )
-//                    }
-//                }
-//                
-//                completion(data, error)
-//            }
-//            task.resume()
-            
         case .frigate:
-            guard let jwt = try? await generateJWTFrigate() else {
+            guard let target = splitAbsoluteURL(urlString) else {
+                let error = makeError(
+                    domain: "InvalidURL",
+                    code: 0,
+                    message: "Invalid image URL for Frigate auth: \(urlString)"
+                )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchImage", "Failed to generate Frigate JWT"
+                    fn: "fetchImage",
+                    error.localizedDescription
                 )
+                finish(completion: completion, data: nil, error: error)
                 return
             }
-            await connectToFrigateAPIWithJWT(
-                host: urlString,
-                jwtToken: jwt,
-                endpoint: ""
+
+            await AuthFrigateLogin.shared.connect(
+                host: target.host,
+                endpoint: target.endpoint
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         case .bearer:
             guard let jwt = try? await generateJWTBearer() else {
+                let error = makeError(
+                    code: 503,
+                    message: "Failed to generate bearer JWT"
+                )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchImage", "Failed to generate bearer JWT"
+                    fn: "fetchImage",
+                    error.localizedDescription
                 )
+                finish(completion: completion, data: nil, error: error)
                 return
             }
+
+            guard let target = splitAbsoluteURL(urlString) else {
+                let error = makeError(
+                    domain: "InvalidURL",
+                    code: 0,
+                    message: "Invalid image URL for bearer auth: \(urlString)"
+                )
+                Log.error(
+                    page: "APIRequestor",
+                    fn: "fetchImage",
+                    error.localizedDescription
+                )
+                finish(completion: completion, data: nil, error: error)
+                return
+            }
+
             await connectWithJWT(
-                host: urlString,
+                host: target.host,
                 jwtToken: jwt,
-                endpoint: ""
+                endpoint: target.endpoint
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         case .cloudflare:
-            await AuthCloudFlare.shared().connectWithCloudflareAccess(
-                host: urlString,
-                endpoint: ""
-            ) { data, error in
-                completion(data, error)
+            guard let target = splitAbsoluteURL(urlString) else {
+                let error = makeError(
+                    domain: "InvalidURL",
+                    code: 0,
+                    message: "Invalid image URL for Cloudflare auth: \(urlString)"
+                )
+                Log.error(
+                    page: "APIRequestor",
+                    fn: "fetchImage",
+                    error.localizedDescription
+                )
+                finish(completion: completion, data: nil, error: error)
+                return
             }
-            
+
+            await AuthCloudFlare.shared().connectWithCloudflareAccess(
+                host: target.host,
+                endpoint: target.endpoint
+            ) { data, error in
+                self.finish(completion: completion, data: data, error: error)
+            }
+
         default:
+            let error = makeError(
+                code: 400,
+                message: "unsupported authType \(authType)"
+            )
             Log.error(
                 page: "APIRequestor",
-                fn: "fetchImage", "unsupported authType \(authType)"
+                fn: "fetchImage",
+                error.localizedDescription
             )
+            finish(completion: completion, data: nil, error: error)
         }
     }
-    
+
     // MARK: - Config
-    
+
     func fetchNVRConfig(
         urlString: String,
         authType: AuthType,
@@ -536,129 +616,98 @@ final class APIRequester: NSObject {
         switch authType {
         case .none:
             guard let url = makeURL(base: urlString, endpoint: "/api/config") else {
-                let error = NSError(
+                let error = makeError(
                     domain: "InvalidURL",
                     code: 0,
-                    userInfo: [NSLocalizedDescriptionKey: "Invalid URL in fetchNVRConfig: base=\(urlString)"]
+                    message: "Invalid URL in fetchNVRConfig: base=\(urlString)"
                 )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchNVRConfig", error.localizedDescription
+                    fn: "fetchNVRConfig",
+                    error.localizedDescription
                 )
-                completion(nil, error)
+                finish(completion: completion, data: nil, error: error)
                 return
             }
 
-            var request = URLRequest(url: url)
-            request.httpMethod = "GET"
+            performRequest(url: url, method: "GET", completion: completion)
 
-            let session = URLSession(
-                configuration: .default,
-                delegate: self,
-                delegateQueue: .main
-            )
-
-            let task = session.dataTask(with: request) { data, _, error in
-                completion(data, error)
-            }
-            task.resume()
-
-//            let fullURLString = "\(urlString)/api/config"
-//            guard let url = URL(string: fullURLString) else {
-//                Log.error(
-//                    page: "APIRequestor",
-//                    fn: "fetchNVRConfig", "Invalid URL: \(fullURLString)"
-//                )
-//                return
-//            }
-//            
-//            var request = URLRequest(url: url)
-//            request.httpMethod = "GET"
-//            
-//            let session = URLSession(
-//                configuration: .default,
-//                delegate: self,
-//                delegateQueue: .main
-//            )
-//            
-//            let task = session.dataTask(with: request) { data, _, error in
-//                completion(data, error)
-//            }
-//            task.resume()
-            
         case .frigate:
-            guard let jwt = try? await generateJWTFrigate() else {
-                Log.error(
-                    page: "APIRequestor",
-                    fn: "fetchNVRConfig", "Failed to generate Frigate JWT"
-                )
-                return
-            }
-            await connectToFrigateAPIWithJWT(
+            await AuthFrigateLogin.shared.connect(
                 host: urlString,
-                jwtToken: jwt,
                 endpoint: "/api/config"
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         case .bearer:
             guard let jwt = try? await generateJWTBearer() else {
+                let error = makeError(
+                    code: 503,
+                    message: "Failed to generate bearer JWT"
+                )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "fetchNVRConfig", "Failed to generate bearer JWT"
+                    fn: "fetchNVRConfig",
+                    error.localizedDescription
                 )
+                finish(completion: completion, data: nil, error: error)
                 return
             }
+
             await connectWithJWT(
                 host: urlString,
                 jwtToken: jwt,
                 endpoint: "/api/config"
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         case .cloudflare:
             await AuthCloudFlare.shared().connectWithCloudflareAccess(
                 host: urlString,
                 endpoint: "/api/config"
             ) { data, error in
-                completion(data, error)
+                self.finish(completion: completion, data: data, error: error)
             }
-            
+
         default:
+            let error = makeError(
+                code: 400,
+                message: "unsupported authType \(authType)"
+            )
             Log.error(
                 page: "APIRequestor",
-                fn: "fetchNVRConfig", "unsupported authType \(authType)"
+                fn: "fetchNVRConfig",
+                error.localizedDescription
             )
+            finish(completion: completion, data: nil, error: error)
         }
     }
-    
+
     // MARK: - Connection check
-    
+
     func checkConnectionStatus(
         urlString: String,
         authType: AuthType,
         completion: @escaping (Data?, Error?) -> Void
     ) async throws {
 
-        // Helper to build a simple NSError
-        func makeError(_ message: String, code: Int = 500) -> NSError {
-            NSError(
-                domain: "connection.info",
-                code: code,
-                userInfo: [NSLocalizedDescriptionKey: message]
-            )
-        }
-
         switch authType {
         case .none:
             guard let url = makeURL(base: urlString, endpoint: "/api/version") else {
+                let error = makeError(
+                    domain: "connection.info",
+                    code: 400,
+                    message: "Invalid URL \(urlString)/api/version"
+                )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "checkConnectionStatus", "Invalid URL - base=\(urlString)"
+                    fn: "checkConnectionStatus",
+                    error.localizedDescription
                 )
-                return completion(nil, makeError("Invalid URL \(urlString)/api/version", code: 400))
+                finish(completion: completion, data: nil, error: error)
+                return
             }
 
             var request = URLRequest(url: url)
@@ -671,173 +720,85 @@ final class APIRequester: NSObject {
             )
 
             let task = session.dataTask(with: request) { data, response, error in
+                defer { session.finishTasksAndInvalidate() }
 
                 if let error = error {
                     Log.error(
                         page: "APIRequestor",
-                        fn: "checkConnectionStatus", "\(error.localizedDescription)"
+                        fn: "checkConnectionStatus",
+                        error.localizedDescription
                     )
-                    let errorTemp = makeError(
-                        "Network error: \(error.localizedDescription) - \(url.absoluteString)"
+                    let errorTemp = self.makeError(
+                        domain: "connection.info",
+                        code: 500,
+                        message: "Network error: \(error.localizedDescription) - \(url.absoluteString)"
                     )
-                    return completion(nil, errorTemp)
+                    self.finish(completion: completion, data: nil, error: errorTemp)
+                    return
                 }
 
                 guard let httpResponse = response as? HTTPURLResponse else {
                     Log.error(
                         page: "APIRequestor",
-                        fn: "connection.info:invalid response", "Invalid Response - \(url.absoluteString)"
+                        fn: "connection.info:invalid response",
+                        "Invalid Response - \(url.absoluteString)"
                     )
-                    return completion(nil, makeError("Invalid HTTP response"))
+                    self.finish(
+                        completion: completion,
+                        data: nil,
+                        error: self.makeError(domain: "connection.info", code: 500, message: "Invalid HTTP response")
+                    )
+                    return
                 }
 
                 let statusCode = httpResponse.statusCode
-                if statusCode != 200 {
+                guard statusCode == 200 else {
                     Log.error(
                         page: "APIRequestor",
-                        fn: "connection.info:statusCode",  "\(statusCode) - \(url.absoluteString)"
+                        fn: "connection.info:statusCode",
+                        "\(statusCode) - \(url.absoluteString)"
                     )
-                    return completion(nil, makeError("HTTP \(statusCode)", code: statusCode))
-                }
-
-                guard let data = data, !data.isEmpty else {
-                    Log.error(
-                        page: "APIRequestor",
-                        fn: "connection.info:dataEmpty", "DATA_EMPTY - \(url.absoluteString)"
+                    self.finish(
+                        completion: completion,
+                        data: nil,
+                        error: self.makeError(domain: "connection.info", code: statusCode, message: "HTTP \(statusCode)")
                     )
-                    return completion(nil, makeError("Empty response", code: 502))
+                    return
                 }
 
-                if let firstByte = data.first {
-                    let firstByteData = Data([firstByte])
-                    if let firstCharacterString = String(data: firstByteData, encoding: .utf8) {
-                        let character = Character(firstCharacterString)
-                        if !character.isWholeNumber {
-                            Log.error(
-                                page: "APIRequestor",
-                                fn: "connection.info:notDigit", "NOT_WHOLE_NUMBER - \(url.absoluteString)"
-                            )
-                            return completion(nil, makeError("Unexpected response format", code: 501))
-                        }
-                    }
-                }
-
-                completion(data, nil)
+                self.validateVersionPayload(
+                    data: data,
+                    error: nil,
+                    completion: completion
+                )
             }
 
             task.resume()
 
-//            let fullUrlString = urlString + "/api/version"
-//            guard let url = URL(string: fullUrlString) else {
-//                Log.error(
-//                    page: "APIRequestor",
-//                    fn: "checkConnectionStatus", "Invalid URL - \(fullUrlString)"
-//                )
-//                return completion(nil, makeError("Invalid URL \(fullUrlString)", code: 400))
-//            }
-//
-//            var request = URLRequest(url: url)
-//            request.httpMethod = "GET"
-//
-//            let session = URLSession(
-//                configuration: .default,
-//                delegate: self,
-//                delegateQueue: .main
-//            )
-//
-//            let task = session.dataTask(with: request) { data, response, error in
-//
-//                if let error = error {
-//                    Log.error(
-//                        page: "APIRequestor",
-//                        fn: "checkConnectionStatus", "\(error.localizedDescription)"
-//                    )
-//                    let errorTemp = makeError(
-//                        "Network error: \(error.localizedDescription) - \(fullUrlString)"
-//                    )
-//                    return completion(nil, errorTemp)
-//                }
-//
-//                guard let httpResponse = response as? HTTPURLResponse else {
-//                    Log.error(
-//                        page: "APIRequestor",
-//                        fn: "connection.info:invalid response", "Invalid Response - \(fullUrlString)"
-//                    )
-//                    return completion(nil, makeError("Invalid HTTP response"))
-//                }
-//
-//                let statusCode = httpResponse.statusCode
-//                if statusCode != 200 {
-//                    Log.error(
-//                        page: "APIRequestor",
-//                        fn: "connection.info:statusCode",  "\(statusCode) - \(fullUrlString)"
-//                    )
-//                    return completion(nil, makeError("HTTP \(statusCode)", code: statusCode))
-//                }
-//
-//                // Validate first byte is a digit
-//                guard let data = data, !data.isEmpty else {
-//                    Log.error(
-//                        page: "APIRequestor",
-//                        fn: "connection.info:dataEmpty", "DATA_EMPTY - \(fullUrlString)"
-//                    )
-//                    return completion(nil, makeError("Empty response", code: 502))
-//                }
-//
-//                if let firstByte = data.first {
-//                    let firstByteData = Data([firstByte])
-//                    if let firstCharacterString = String(data: firstByteData, encoding: .utf8) {
-//                        let character = Character(firstCharacterString)
-//                        if !character.isWholeNumber {
-//                            Log.error(
-//                                page: "APIRequestor",
-//                                fn: "connection.info:notDigit", "NOT_WHOLE_NUMBER - \(fullUrlString)"
-//                            )
-//                            return completion(nil, makeError("Unexpected response format", code: 501))
-//                        }
-//                    }
-//                }
-//
-//                completion(data, nil)
-//            }
-//
-//            task.resume()
-
         case .frigate:
-            guard let jwt = try? await generateJWTFrigate() else {
-                return completion(nil, makeError("Failed to generate Frigate JWT", code: 503))
-            }
-
-            await connectToFrigateAPIWithJWT(
+            await AuthFrigateLogin.shared.connect(
                 host: urlString,
-                jwtToken: jwt,
                 endpoint: "/api/version"
             ) { data, error in
-
-                if let error = error {
-                    return completion(nil, error)
-                }
-
-                guard let data = data, !data.isEmpty else {
-                    return completion(nil, makeError("Empty response", code: 500))
-                }
-
-                if let firstByte = data.first {
-                    let firstByteData = Data([firstByte])
-                    if let firstCharacterString = String(data: firstByteData, encoding: .utf8) {
-                        let character = Character(firstCharacterString)
-                        if !character.isWholeNumber {
-                            return completion(nil, makeError("Unexpected response format", code: 500))
-                        }
-                    }
-                }
-
-                return completion(data, nil)
+                self.validateVersionPayload(
+                    data: data,
+                    error: error,
+                    completion: completion
+                )
             }
 
         case .bearer:
             guard let jwt = try? await generateJWTBearer() else {
-                return completion(nil, makeError("Failed to generate bearer JWT", code: 503))
+                finish(
+                    completion: completion,
+                    data: nil,
+                    error: makeError(
+                        domain: "connection.info",
+                        code: 503,
+                        message: "Failed to generate bearer JWT"
+                    )
+                )
+                return
             }
 
             await connectWithJWT(
@@ -845,26 +806,11 @@ final class APIRequester: NSObject {
                 jwtToken: jwt,
                 endpoint: "/api/version"
             ) { data, error in
-
-                if let error = error {
-                    return completion(nil, error)
-                }
-
-                guard let data = data, !data.isEmpty else {
-                    return completion(nil, makeError("Empty response", code: 500))
-                }
-
-                if let firstByte = data.first {
-                    let firstByteData = Data([firstByte])
-                    if let firstCharacterString = String(data: firstByteData, encoding: .utf8) {
-                        let character = Character(firstCharacterString)
-                        if !character.isWholeNumber {
-                            return completion(nil, makeError("Unexpected response format", code: 500))
-                        }
-                    }
-                }
-
-                return completion(data, nil)
+                self.validateVersionPayload(
+                    data: data,
+                    error: error,
+                    completion: completion
+                )
             }
 
         case .cloudflare:
@@ -872,36 +818,27 @@ final class APIRequester: NSObject {
                 host: urlString,
                 endpoint: "/api/version"
             ) { data, error in
-
-                if let error = error {
-                    return completion(nil, error)
-                }
-
-                guard let data = data, !data.isEmpty else {
-                    return completion(nil, makeError("Empty response", code: 500))
-                }
-
-                if let firstByte = data.first {
-                    let firstByteData = Data([firstByte])
-                    if let firstCharacterString = String(data: firstByteData, encoding: .utf8) {
-                        let character = Character(firstCharacterString)
-                        if !character.isWholeNumber {
-                            return completion(nil, makeError("Unexpected response format", code: 500))
-                        }
-                    }
-                }
-
-                return completion(data, nil)
+                self.validateVersionPayload(
+                    data: data,
+                    error: error,
+                    completion: completion
+                )
             }
 
         default:
-            let fullUrlString = urlString + "/api/version"
-            guard let url = URL(string: fullUrlString) else {
+            guard let url = makeURL(base: urlString, endpoint: "/api/version") else {
+                let error = makeError(
+                    domain: "connection.info",
+                    code: 400,
+                    message: "Unsupported authType / invalid URL"
+                )
                 Log.error(
                     page: "APIRequestor",
-                    fn: "checkConnectionStatus", "AuthType is unsupported - \(fullUrlString)"
+                    fn: "checkConnectionStatus",
+                    error.localizedDescription
                 )
-                return completion(nil, makeError("Unsupported authType / invalid URL", code: 400))
+                finish(completion: completion, data: nil, error: error)
+                return
             }
 
             var request = URLRequest(url: url)
@@ -914,25 +851,40 @@ final class APIRequester: NSObject {
             )
 
             let task = session.dataTask(with: request) { data, response, error in
+                defer { session.finishTasksAndInvalidate() }
 
                 if let error = error {
-                    return completion(nil, error)
+                    self.finish(completion: completion, data: nil, error: error)
+                    return
                 }
 
                 guard let httpResponse = response as? HTTPURLResponse else {
-                    return completion(nil, makeError("Invalid HTTP response"))
+                    self.finish(
+                        completion: completion,
+                        data: nil,
+                        error: self.makeError(domain: "connection.info", code: 500, message: "Invalid HTTP response")
+                    )
+                    return
                 }
 
                 guard httpResponse.statusCode == 200 else {
-                    return completion(nil, makeError("HTTP \(httpResponse.statusCode)", code: httpResponse.statusCode))
+                    self.finish(
+                        completion: completion,
+                        data: nil,
+                        error: self.makeError(
+                            domain: "connection.info",
+                            code: httpResponse.statusCode,
+                            message: "HTTP \(httpResponse.statusCode)"
+                        )
+                    )
+                    return
                 }
 
-                guard let data = data, !data.isEmpty else {
-                    return completion(nil, makeError("Empty response", code: 500))
-                }
-
-                printData(data)
-                completion(data, nil)
+                self.validateVersionPayload(
+                    data: data,
+                    error: nil,
+                    completion: completion
+                )
             }
             task.resume()
         }
@@ -942,7 +894,7 @@ final class APIRequester: NSObject {
 // MARK: - URLSessionDelegate
 
 extension APIRequester: URLSessionDelegate {
-    
+
     func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
@@ -955,12 +907,13 @@ extension APIRequester: URLSessionDelegate {
             completionHandler(.performDefaultHandling, nil)
         }
     }
-    
+
     func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
         if let err = error {
             Log.error(
                 page: "APIRequestor",
-                fn: "urlSession", err.localizedDescription
+                fn: "urlSession",
+                err.localizedDescription
             )
         }
     }
@@ -972,4 +925,3 @@ struct FrigateResponse: Codable {
     let message: String?
     let success: Bool?
 }
-


### PR DESCRIPTION
- switched from JWT to username password auth mode
- moved Frigate auth secrets to Keychain, split auth into dedicated stores, and update APIRequester for the new login flow
- add KeychainStore and FrigateCredentialStore for secure storage of Frigate username, password, and tokens
- refactor AuthFrigateLogin to use Keychain-backed credentials and token retrieval
- update APIRequester to work with the new Frigate auth flow and fix .frigate endpoint handling for images, config, version, and events